### PR TITLE
feat: 캘린더 페이지 화면 구현

### DIFF
--- a/.idea/navEditor.xml
+++ b/.idea/navEditor.xml
@@ -56,6 +56,18 @@
                       </LayoutPositions>
                     </value>
                   </entry>
+                  <entry key="styleOutfitsFragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="12" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
                   <entry key="wardrobeFragemnt">
                     <value>
                       <LayoutPositions>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,6 @@
         <activity
             android:name=".ClothesDetailActivity"
             android:exported="false" />
-        <activity android:name=".CommunityDetailActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/onfit/CalendarAdapter.kt
+++ b/app/src/main/java/com/example/onfit/CalendarAdapter.kt
@@ -1,0 +1,84 @@
+package com.example.onfit
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.onfit.DaysAdapter
+import com.example.onfit.R
+import com.example.onfit.MonthData
+import java.util.*
+
+class CalendarAdapter(
+    private val months: List<MonthData>,
+    private val registeredDates: Set<String>,
+    private val onDateClick: (String, Boolean) -> Unit
+) : RecyclerView.Adapter<CalendarAdapter.MonthViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MonthViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_month, parent, false)
+        return MonthViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MonthViewHolder, position: Int) {
+        holder.bind(months[position])
+    }
+
+    override fun getItemCount(): Int = months.size
+
+    inner class MonthViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val monthYearText: TextView = itemView.findViewById(R.id.monthYearText)
+        private val daysRecyclerView: RecyclerView = itemView.findViewById(R.id.daysRecyclerView)
+
+        fun bind(monthData: MonthData) {
+            monthYearText.text = "${monthData.year}.${monthData.month}"
+
+            // 날짜 데이터 생성
+            val days = generateDaysForMonth(monthData.year, monthData.month)
+
+            // 날짜 어댑터 설정
+            val daysAdapter = DaysAdapter(days, registeredDates, onDateClick)
+            daysRecyclerView.apply {
+                layoutManager = GridLayoutManager(itemView.context, 7)
+                adapter = daysAdapter
+            }
+        }
+
+        private fun generateDaysForMonth(year: Int, month: Int): List<DayData> {
+            val days = mutableListOf<DayData>()
+            val calendar = Calendar.getInstance()
+
+            // 해당 월의 첫 번째 날로 설정
+            calendar.set(year, month - 1, 1)
+
+            // 월의 첫 번째 날의 요일 (일요일 = 1, 월요일 = 2, ...)
+            val firstDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
+
+            // 빈 칸 추가 (일요일 시작 기준)
+            repeat(firstDayOfWeek - 1) {
+                days.add(DayData(0, "", false))
+            }
+
+            // 해당 월의 마지막 날
+            val lastDay = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+            // 날짜 추가
+            for (day in 1..lastDay) {
+                val dateString = String.format("%04d-%02d-%02d", year, month, day)
+                val hasData = registeredDates.contains(dateString)
+                days.add(DayData(day, dateString, hasData))
+            }
+
+            return days
+        }
+    }
+}
+
+data class DayData(
+    val day: Int,
+    val dateString: String,
+    val hasData: Boolean
+)

--- a/app/src/main/java/com/example/onfit/CalendarFragment.kt
+++ b/app/src/main/java/com/example/onfit/CalendarFragment.kt
@@ -1,59 +1,209 @@
 package com.example.onfit
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.PagerSnapHelper
+import androidx.recyclerview.widget.RecyclerView
+import java.util.*
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [CalendarFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class CalendarFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
+    private lateinit var rvCalendar: RecyclerView
+    private lateinit var calendarAdapter: CalendarAdapter
+
+    // 코디가 등록된 날짜들 (예시 데이터)
+    private val outfitRegisteredDates = setOf(
+        "2025-04-03", "2025-04-04", "2025-04-05", "2025-04-06", "2025-04-07",
+        "2025-04-08", "2025-04-09", "2025-04-10", "2025-04-11", "2025-04-12",
+        "2025-04-13", "2025-04-14", "2025-04-15", "2025-04-16", "2025-04-17",
+        "2025-04-18", "2025-04-19", "2025-04-20", "2025-04-21", "2025-04-22",
+        "2025-04-23", "2025-04-24", "2025-04-25", "2025-04-26", "2025-04-27",
+        "2025-04-28", "2025-04-29",
+        "2025-07-03", "2025-07-04", "2025-07-05", "2025-07-06", "2025-07-07",
+        "2025-07-08", "2025-07-09", "2025-07-10", "2025-07-11", "2025-07-12",
+        "2025-07-13", "2025-07-14", "2025-07-15", "2025-07-16", "2025-07-17",
+        "2025-07-18", "2025-07-19", "2025-07-20", "2025-07-21", "2025-07-22",
+        "2025-07-23", "2025-07-24", "2025-07-25", "2025-07-26", "2025-07-27",
+        "2025-07-28", "2025-07-29"
+    )
+
+    // 스타일 태그별 개수 (예시 데이터)
+    private val styleTagCounts = mapOf(
+        "포멀" to 15,
+        "캐주얼" to 12,
+        "빈티지" to 8,
+        "미니멀" to 6
+    )
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_calendar, container, false)
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment CalendarFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            CalendarFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupViews(view)
+        setupCalendar()
+        updateMostUsedStyleText()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Fragment가 다시 보일 때마다 현재 월로 스크롤
+        rvCalendar.post {
+            try {
+                val currentMonthIndex = 24
+                (rvCalendar.layoutManager as? LinearLayoutManager)?.scrollToPositionWithOffset(currentMonthIndex, 0)
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
+        }
+    }
+
+    private fun setupViews(view: View) {
+        rvCalendar = view.findViewById(R.id.rvCalendar)
+
+        // 스타일별 Outfit 보기 버튼 클릭 리스너
+        view.findViewById<View>(R.id.btnStyleOutfits)?.setOnClickListener {
+            Toast.makeText(requireContext(), "버튼 클릭됨!", Toast.LENGTH_SHORT).show()
+            navigateToStyleOutfits()
+        } ?: run {
+            Toast.makeText(requireContext(), "버튼을 찾을 수 없습니다!", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun setupCalendar() {
+        // 현재 날짜 기준으로 이전 12개월, 이후 12개월 데이터 생성
+        val months = generateMonths()
+
+        calendarAdapter = CalendarAdapter(
+            months = months,
+            registeredDates = outfitRegisteredDates,
+            onDateClick = { dateString, hasOutfit ->
+                handleDateClick(dateString, hasOutfit)
+            }
+        )
+
+        rvCalendar.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = calendarAdapter
+
+            // 스냅 헬퍼 추가 (한 번에 한 달씩 스크롤)
+            PagerSnapHelper().attachToRecyclerView(this)
+        }
+
+        // 현재 월로 스크롤 (처음 화면 진입 시)
+        scrollToCurrentMonth()
+    }
+
+    private fun generateMonths(): List<MonthData> {
+        val months = mutableListOf<MonthData>()
+        val calendar = Calendar.getInstance()
+
+        // 현재 날짜에서 24개월 전으로 시작
+        calendar.add(Calendar.MONTH, -24)
+
+        // 총 37개월 생성 (이전 24개월 + 현재 월 + 이후 12개월)
+        repeat(37) {
+            val year = calendar.get(Calendar.YEAR)
+            val month = calendar.get(Calendar.MONTH) + 1
+
+            // 각 달의 날짜 데이터도 함께 생성
+            val monthData = MonthData(year, month).apply {
+                // MonthData에 날짜 리스트가 있다면 여기서 생성
+                // 이 부분은 실제 MonthData 클래스 구조에 따라 달라짐
+            }
+
+            months.add(monthData)
+            calendar.add(Calendar.MONTH, 1)
+        }
+
+        return months
+    }
+
+    private fun scrollToCurrentMonth() {
+        // 현재 월 인덱스 (이전 24개월 후)
+        val currentMonthIndex = 24
+        rvCalendar.post {
+            // 뷰가 완전히 렌더링된 후 스크롤
+            rvCalendar.postDelayed({
+                try {
+                    // smoothScrollToPosition 대신 scrollToPosition 사용
+                    (rvCalendar.layoutManager as? LinearLayoutManager)?.scrollToPositionWithOffset(currentMonthIndex, 0)
+                } catch (e: Exception) {
+                    // 실패 시 기본 스크롤
+                    rvCalendar.scrollToPosition(currentMonthIndex)
+                }
+            }, 100) // 100ms 지연 후 스크롤
+        }
+    }
+
+    private fun updateMostUsedStyleText() {
+        val mostUsedStyle = styleTagCounts.maxByOrNull { it.value }?.key ?: "포밍"
+        view?.findViewById<TextView>(R.id.tvMostUsedStyle)?.text =
+            "#${mostUsedStyle} 스타일이 가장 많았어요!"
+    }
+
+    private fun handleDateClick(dateString: String, hasOutfit: Boolean) {
+        if (hasOutfit) {
+            // 코디가 등록되어 있는 날짜 클릭 → 코디 상세 화면으로 이동
+            navigateToOutfitDetail(dateString)
+        } else {
+            // 코디가 등록되어 있지 않은 날짜 클릭 → outfit 등록 flow로 이동
+            navigateToOutfitRegister(dateString)
+        }
+    }
+
+    private fun navigateToOutfitDetail(dateString: String) {
+        // TODO: 코디 상세 화면으로 이동
+        // findNavController().navigate(
+        //     CalendarFragmentDirections.actionCalendarToOutfitDetail(dateString)
+        // )
+    }
+
+    private fun navigateToOutfitRegister(dateString: String) {
+        // TODO: 코디 등록 화면으로 이동
+        // findNavController().navigate(
+        //     CalendarFragmentDirections.actionCalendarToOutfitRegister(dateString)
+        // )
+    }
+
+    private fun navigateToStyleOutfits() {
+        try {
+            // Navigation 안전성 확인
+            val navController = findNavController()
+            val currentDestination = navController.currentDestination
+
+            // StyleOutfitsFragment가 navigation graph에 있는지 확인
+            val targetDestination = navController.graph.findNode(R.id.styleOutfitsFragment)
+
+            if (targetDestination != null) {
+                navController.navigate(R.id.styleOutfitsFragment)
+            } else {
+                Toast.makeText(requireContext(), "StyleOutfitsFragment를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Toast.makeText(requireContext(), "Navigation 오류: ${e.message}", Toast.LENGTH_LONG).show()
+        }
     }
 }
+
+data class MonthData(
+    val year: Int,
+    val month: Int
+)

--- a/app/src/main/java/com/example/onfit/DaysAdapter.kt
+++ b/app/src/main/java/com/example/onfit/DaysAdapter.kt
@@ -1,0 +1,57 @@
+package com.example.onfit
+
+import android.graphics.drawable.GradientDrawable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.example.onfit.DayData
+
+class DaysAdapter(
+    private val days: List<DayData>,
+    private val registeredDates: Set<String>,
+    private val onDateClick: (String, Boolean) -> Unit
+) : RecyclerView.Adapter<DaysAdapter.DayViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DayViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_day, parent, false)
+        return DayViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: DayViewHolder, position: Int) {
+        holder.bind(days[position])
+    }
+
+    override fun getItemCount(): Int = days.size
+
+    inner class DayViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val tvDay: TextView = itemView.findViewById(R.id.tvDay)
+        private val vOutfitIndicator: View = itemView.findViewById(R.id.vOutfitIndicator)
+
+        fun bind(dayData: DayData) {
+            if (dayData.day == 0) {
+                // 빈 칸
+                tvDay.text = ""
+                vOutfitIndicator.visibility = View.GONE
+                itemView.setOnClickListener(null)
+            } else {
+                tvDay.text = dayData.day.toString()
+
+                // 코디 등록 표시 점 표시/숨김
+                if (dayData.hasData) {
+                    vOutfitIndicator.visibility = View.VISIBLE
+                } else {
+                    vOutfitIndicator.visibility = View.GONE
+                }
+
+                // 날짜 클릭 리스너
+                itemView.setOnClickListener {
+                    onDateClick(dayData.dateString, dayData.hasData)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/onfit/StyleOutfitsFragment.kt
+++ b/app/src/main/java/com/example/onfit/StyleOutfitsFragment.kt
@@ -1,0 +1,238 @@
+package com.example.onfit
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import android.view.Gravity
+import android.widget.HorizontalScrollView
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+class StyleOutfitsFragment : Fragment() {
+
+    private lateinit var rvOutfitItems: RecyclerView
+    private lateinit var wardrobeAdapter: WardrobeAdapter
+    private lateinit var styleFilterLayout: LinearLayout
+    private lateinit var styleFilterScrollView: HorizontalScrollView
+
+    // 전체 의류 아이템 (WardrobeFragment와 완전히 동일)
+    private val allImageList = listOf(
+        R.drawable.clothes1,
+        R.drawable.clothes2,
+        R.drawable.clothes3,
+        R.drawable.clothes4,
+        R.drawable.clothes5,
+        R.drawable.clothes6,
+        R.drawable.clothes7,
+        R.drawable.clothes8,
+        R.drawable.cody_image1,
+        R.drawable.cody_image4,
+        R.drawable.cody_image5
+    )
+
+    // 스타일 필터 목록
+    private val styleFilters = listOf("포멀", "빈티지", "미니멀", "캐주얼", "꾸안꾸")
+    private val styleTagCounts = mapOf(
+        "포멀" to 10,
+        "빈티지" to 10,
+        "미니멀" to 10,
+        "캐주얼" to 10,
+        "꾸안꾸" to 10
+    )
+
+    // 현재 선택된 인덱스
+    private var selectedStyleIndex = 0
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_style_outfits, container, false)
+
+        initializeViews(view)
+        setupRecyclerView()
+        setupStyleFilters()
+        setupBackButton(view)
+
+        return view
+    }
+
+    private fun initializeViews(view: View) {
+        rvOutfitItems = view.findViewById(R.id.rvOutfitItems)
+        styleFilterLayout = view.findViewById(R.id.styleFilterLayout)
+        styleFilterScrollView = view.findViewById(R.id.styleFilterScrollView)
+    }
+
+    private fun setupRecyclerView() {
+        // 기존 WardrobeAdapter 사용 - 클래스 중복 문제 해결
+        wardrobeAdapter = WardrobeAdapter(allImageList) { imageResId ->
+            navigateToClothesDetail(imageResId)
+        }
+        rvOutfitItems.layoutManager = GridLayoutManager(requireContext(), 2)
+        rvOutfitItems.adapter = wardrobeAdapter
+    }
+
+    private fun navigateToClothesDetail(imageResId: Int) {
+        // WardrobeFragment와 동일한 방식으로 ClothesDetailActivity로 이동
+        try {
+            val intent = Intent(requireContext(), ClothesDetailActivity::class.java)
+            intent.putExtra("image_res_id", imageResId)
+            startActivity(intent)
+        } catch (e: Exception) {
+            // ClothesDetailActivity가 없는 경우 무시
+            e.printStackTrace()
+        }
+    }
+
+    private fun setupStyleFilters() {
+        // 스타일 필터 버튼들 생성
+        styleFilters.forEachIndexed { index, styleName ->
+            val button = createStyleFilterButton(styleName, index)
+            styleFilterLayout.addView(button)
+        }
+
+        // 첫 번째 버튼을 기본 선택으로 설정
+        updateStyleButtonSelection(0)
+    }
+
+    private fun createStyleFilterButton(styleName: String, index: Int): Button {
+        val count = styleTagCounts[styleName] ?: 0
+        val buttonText = "$styleName $count"
+
+        val button = Button(requireContext()).apply {
+            text = buttonText
+            setTextColor(ContextCompat.getColor(context, android.R.color.black))
+            background = try {
+                ContextCompat.getDrawable(context, R.drawable.style_tag_background)
+            } catch (e: Exception) {
+                // 리소스가 없는 경우 기본 배경 사용
+                null
+            }
+            setPadding(dpToPx(1), dpToPx(0), dpToPx(1), dpToPx(0)) // 좌우 8px, 상하 7px
+            textSize = 14f
+            isAllCaps = false
+            minWidth = dpToPx(49)
+            minHeight = 0
+            setSingleLine(true)
+            gravity = Gravity.CENTER
+
+            // intermedium 폰트 적용
+            try {
+                typeface = resources.getFont(R.font.intermedium)
+            } catch (e: Exception) {
+                // 폰트가 없는 경우 기본 폰트 사용
+                e.printStackTrace()
+            }
+        }
+
+        // 버튼 레이아웃 파라미터 설정
+        val buttonParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            if (index > 0) leftMargin = dpToPx(8) // 버튼 간격
+        }
+        button.layoutParams = buttonParams
+
+        // 클릭 리스너
+        button.setOnClickListener {
+            updateStyleButtonSelection(index)
+            filterOutfitsByStyle(styleName)
+        }
+
+        return button
+    }
+
+    private fun updateStyleButtonSelection(newSelectedIndex: Int) {
+        if (!isAdded || context == null) return
+
+        try {
+            // 모든 버튼을 기본 상태로 변경
+            for (i in 0 until styleFilterLayout.childCount) {
+                val button = styleFilterLayout.getChildAt(i) as? Button
+                button?.isSelected = false
+                button?.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.black))
+            }
+
+            // 선택된 버튼 상태 변경
+            if (newSelectedIndex < styleFilterLayout.childCount) {
+                val selectedButton = styleFilterLayout.getChildAt(newSelectedIndex) as? Button
+                selectedButton?.isSelected = true
+                selectedButton?.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
+            }
+
+            selectedStyleIndex = newSelectedIndex
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun filterOutfitsByStyle(styleName: String) {
+        // TODO: 스타일에 따른 필터링 로직 구현
+        // 현재는 모든 아이템 표시
+        // 예시: 특정 스타일에 따라 이미지 리스트 필터링
+    }
+
+    private fun setupBackButton(view: View) {
+        view.findViewById<View>(R.id.ic_back)?.setOnClickListener {
+            try {
+                requireActivity().onBackPressed()
+            } catch (e: Exception) {
+                // Fragment가 attach되지 않은 경우 처리
+                e.printStackTrace()
+            }
+        }
+    }
+
+    // dp를 px로 변환하는 헬퍼 함수
+    private fun dpToPx(dp: Int): Int {
+        return (dp * resources.displayMetrics.density).toInt()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        try {
+            if (::rvOutfitItems.isInitialized) {
+                rvOutfitItems.adapter = null
+            }
+            if (::styleFilterLayout.isInitialized) {
+                styleFilterLayout.removeAllViews()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // StyleOutfitsFragment가 시작될 때 bottom navigation 숨기기
+        try {
+            val activity = requireActivity()
+            // MainActivity에서 실제 사용하는 bottomNavigationView
+            val bottomNav = activity.findViewById<View>(R.id.bottomNavigationView)
+            bottomNav?.visibility = View.GONE
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // StyleOutfitsFragment가 멈출 때 bottom navigation 다시 보이기
+        try {
+            val activity = requireActivity()
+            val bottomNav = activity.findViewById<View>(R.id.bottomNavigationView)
+            bottomNav?.visibility = View.VISIBLE
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/res/color/style_tag_text_color.xml
+++ b/app/src/main/res/color/style_tag_text_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 선택된 상태 -->
+    <item android:state_selected="true" android:color="@android:color/white" />
+
+    <!-- 기본 상태 -->
+    <item android:color="@android:color/black" />
+</selector>

--- a/app/src/main/res/drawable/blue_dot.xml
+++ b/app/src/main/res/drawable/blue_dot.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/basic_blue" />
+    <size
+        android:width="10dp"
+        android:height="10dp" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M15.41,7.41L14,6L8,12L14,18L15.41,16.59L10.83,12Z" />
+
+</vector>

--- a/app/src/main/res/drawable/month_border.xml
+++ b/app/src/main/res/drawable/month_border.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 배경 -->
+    <item>
+        <shape>
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+
+    <!-- 하단 구분선 -->
+    <item android:gravity="bottom">
+        <shape android:shape="rectangle">
+            <size android:height="1dp" />
+            <solid android:color="#F0F0F0" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/placeholder_image.xml
+++ b/app/src/main/res/drawable/placeholder_image.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#F0F0F0" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/drawable/style_tag_background.xml
+++ b/app/src/main/res/drawable/style_tag_background.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- 선택된 상태 -->
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/black" />
+            <corners android:radius="30dp" />
+        </shape>
+    </item>
+
+    <!-- 기본 상태 -->
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/tag_background_gray" />
+            <corners android:radius="30dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -1,14 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".CalendarFragment">
+    android:orientation="vertical">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <!-- 상단 헤더 -->
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp"
+        android:background="@android:color/white"
+        android:layout_marginTop="38dp">
 
-</FrameLayout>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="최근 한달 간"
+            android:textSize="17sp"
+            android:fontFamily="@font/pretendardbold"
+            android:textColor="@android:color/black"
+            android:layout_marginBottom="4dp" />
+
+        <TextView
+            android:id="@+id/tvMostUsedStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="#포멀 스타일이 가장 많았어요!"
+            android:textSize="17sp"
+            android:fontFamily="@font/pretendardbold"
+            android:textColor="@android:color/black"
+            android:layout_marginBottom="16dp" />
+
+        <android.widget.Button
+            android:id="@+id/btnStyleOutfits"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="스타일 별 Outfit 보기"
+            android:textColor="@android:color/white"
+            android:background="@drawable/rounded_button"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            style="?android:attr/borderlessButtonStyle" />
+    </LinearLayout>
+
+    <!-- 캘린더 스크롤뷰 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvCalendar"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="@android:color/white"
+        android:padding="16dp"
+        android:clipToPadding="false"
+        android:scrollbars="none" />
+
+    <ImageButton
+        android:id="@+id/outfit_register_btn"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="24dp"
+        android:src="@drawable/ic_add"
+        android:background="@drawable/circle_button"
+        android:contentDescription="outfit 등록"
+        android:scaleType="center"
+        android:elevation="0dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_style_outfits.xml
+++ b/app/src/main/res/layout/fragment_style_outfits.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/style_outfits_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/white">
+
+    <!-- 상단 헤더 -->
+
+    <!-- 스타일 필터 버튼들 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:layout_marginTop="38dp">
+
+        <ImageButton
+            android:id="@+id/ic_back"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="뒤로가기"
+            android:src="@drawable/leftarrow" />
+
+
+    </LinearLayout>
+
+    <HorizontalScrollView
+        android:id="@+id/styleFilterScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp">
+
+        <LinearLayout
+            android:id="@+id/styleFilterLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
+
+    </HorizontalScrollView>
+
+    <!-- 의류 아이템 그리드 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvOutfitItems"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:padding="16dp"
+        android:clipToPadding="false"
+        android:scrollbars="vertical" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wardrobe_item_select.xml
+++ b/app/src/main/res/layout/fragment_wardrobe_item_select.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_day.xml
+++ b/app/src/main/res/layout/item_day.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <RelativeLayout
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_margin="2dp">
+
+        <TextView
+            android:id="@+id/tvDay"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_centerInParent="true"
+            android:gravity="center"
+            android:text="1"
+            android:textSize="16sp"
+            android:textColor="@android:color/black" />
+
+        <!-- 코디 등록 표시 점 -->
+        <View
+            android:id="@+id/vOutfitIndicator"
+            android:layout_width="8dp"
+            android:layout_height="8dp"
+            android:layout_below="@id/tvDay"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="-3dp"
+            android:background="@drawable/blue_dot"
+            android:visibility="gone" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_month.xml
+++ b/app/src/main/res/layout/item_month.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="372dp"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_marginBottom="16dp"
+    android:paddingBottom="16dp"
+    android:background="@drawable/month_border">
+
+    <!-- 연월 표시 -->
+    <TextView
+        android:id="@+id/monthYearText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="2025.4"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        android:layout_marginBottom="20dp" />
+
+    <!-- 요일 헤더 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="8dp">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="일"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="월"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="화"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="수"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="목"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="금"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="토"
+            android:textSize="14sp"
+            android:textColor="@android:color/darker_gray" />
+
+    </LinearLayout>
+
+    <!-- 날짜 그리드 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/daysRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:nestedScrollingEnabled="false" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_outfit_item.xml
+++ b/app/src/main/res/layout/item_outfit_item.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_margin="4dp">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+        <ImageView
+            android:id="@+id/ivOutfitItem"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop"
+            android:background="@color/item_background"
+            android:src="@drawable/placeholder_image" />
+
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_style_tag.xml
+++ b/app/src/main/res/layout/item_style_tag.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tvStyleTag"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp"
+    android:text="포멀 10"
+    android:textSize="14sp"
+    android:textColor="@color/style_tag_text_color"
+    android:background="@drawable/style_tag_background"
+    android:minWidth="80dp"
+    android:gravity="center" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -29,4 +29,9 @@
         android:name="com.example.onfit.MyPageFragment"
         android:label="마이페이지"/>
 
+    <fragment
+        android:id="@+id/styleOutfitsFragment"
+        android:name="com.example.onfit.StyleOutfitsFragment"
+        android:label="스타일별 Outfit"/>
+
 </navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,7 @@
     <color name="gray_dark">#FF757575</color>
 
     <color name="gray">#808080</color>
+    <color name="nav_text_color">#999999</color>
+    <color name="tag_background_gray">#F0F0F0</color>
+    <color name="item_background">#F8F8F8</color>
 </resources>

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Sat Jul 19 19:51:20 KST 2025
-sdk.dir=C\:\\Users\\jerry\\AppData\\Local\\Android\\Sdk
+#Sun Jul 20 23:28:21 GMT+09:00 2025
+sdk.dir=C\:\\Users\\yang2\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
## ✨ 작업 개요
- 캘린더 메인 화면, 스타일별 outfit 화면 구현

## 🔨 작업 내용
- **새로운 Fragment 생성**
  - StyleOutfitsFragment (스타일별 outfit 목록 화면)
  - CalendarFragment (캘린더 메인 화면)

- **새로운 Adapter 구현**
  - CalendarAdapter (캘린더 월별 네비게이션)
  - DaysAdapter (캘린더 일별 표시 및 상호작용)

- **UI 리소스 추가**
  - **레이아웃 파일**
    - fragment_style_outfits.xml (스타일별 outfit 화면)
    - item_day.xml (캘린더 일별 아이템)
    - item_month.xml (캘린더 월별 아이템)
    - item_outfit_item.xml (outfit 아이템)
    - item_style_tag.xml (스타일 태그)

  - **Drawable 리소스**
    - blue_dot.xml (날짜 표시 점)
    - ic_back.xml (뒤로가기 아이콘)
    - month_border.xml (월 경계선)
    - placeholder_image.xml (플레이스홀더 이미지)
    - style_tag_background.xml (스타일 태그 배경)

  - **Color 리소스**
    - style_tag_text_color.xml (스타일 태그 텍스트 색상)

- **기능 구현**
  - 캘린더 월별/일별 네비게이션
  - 날짜별 outfit 표시 기능
  - 스타일별 outfit 분류 및 표시
  - 캘린더와 옷장 연동 기능

- **네비게이션 연결**
  - nav_graph.xml 업데이트 (캘린더 관련 화면 연결)
  - AndroidManifest.xml 권한 및 설정 추가

## ✅ 체크리스트
- [ ] 주석/변수명 정리
- [ ] 세 명 모두 피드백 완료
- [ ] Merge 전 최신 main 브랜치 반영

## 📸 스크린샷(선택)
<img width="48%" height="48%" alt="캘린더 메인 화면" src="https://github.com/user-attachments/assets/770582f2-4e1c-4127-8663-e7efd3563faf" />
<img width="48%" height="48%" alt="스타일별 outfit 화면" src="https://github.com/user-attachments/assets/095a5c87-0853-427a-bd65-1be3790aa1df" />


## 📌 참고사항
- 캘린더 기본 UI 구현 완료
- 실제 데이터 연동 및 서버 통신은 추후 구현 예정
- 스타일별 outfit 분류 로직은 기본 구조만 구현